### PR TITLE
⚙️반응형 사이즈 설정

### DIFF
--- a/src/shared/styles/_index.scss
+++ b/src/shared/styles/_index.scss
@@ -1,0 +1,3 @@
+@forward 'colors.scss';
+@forward 'fonts.scss';
+@forward 'responsive.scss';

--- a/src/shared/styles/responsive.scss
+++ b/src/shared/styles/responsive.scss
@@ -1,0 +1,54 @@
+@mixin responsive-dimensions($default-width, $default-height) {
+  width: $default-width;
+  height: $default-height;
+
+  @media (min-height: 1px) and (max-height: 480px) {
+    // iPhone 3, 4S
+    width: $default-width * 0.95;
+    height: $default-height * 0.95;
+  }
+  @media (min-height: 481px) and (max-height: 568px) {
+    // iPhone 5, SE 1
+    width: $default-width;
+    height: $default-height;
+  }
+  @media (min-height: 569px) and (max-height: 667px) {
+    // iPhone 6, 6s, 7, 8, SE 2/3
+    height: $default-height * 1.17;
+  }
+  @media (min-height: 668px) and (max-height: 736px) {
+    // iPhone 6+, 6s+, 7+, 8+
+    width: $default-width * 1.22;
+    height: $default-height * 1.22;
+  }
+  @media (min-height: 737px) and (max-height: 812px) {
+    // iPhone X, XS, 11, 12 mini, 13 mini
+    width: $default-width * 1.25;
+    height: $default-height * 1.25;
+  }
+  @media (min-height: 813px) and (max-height: 844px) {
+    // iPhone 12, 12 Pro, 13, 13 Pro, 14, 15
+    width: $default-width * 1.27;
+    height: $default-height * 1.27;
+  }
+  @media (min-height: 845px) and (max-height: 852px) {
+    // iPhone 14 Pro, 15 Pro
+    width: $default-width * 1.27;
+    height: $default-height * 1.27;
+  }
+  @media (min-height: 853px) and (max-height: 896px) {
+    // iPhone XR, XS Max, 11, 11 Pro Max
+    width: $default-width * 1.32;
+    height: $default-height * 1.32;
+  }
+  @media (min-height: 897px) and (max-height: 926px) {
+    // iPhone 12 Pro Max, 13 Pro Max, 14 Plus
+    width: $default-width * 1.32;
+    height: $default-height * 1.32;
+  }
+  @media (min-height: 927px) and (max-height: 932px) {
+    // iPhone 14 Pro Max
+    width: $default-width * 1.35;
+    height: $default-height * 1.35;
+  }
+}


### PR DESCRIPTION
## 작업 이유
- 반응형 사이즈 설정
<br/>

## 작업 사항
### 1️⃣ responsive demensions 구현
- 출시되어있는 iPhone 사이즈에 알맞게 사이즈 설정
```scss
@mixin responsive-dimensions($default-width, $default-height) {
  width: $default-width;
  height: $default-height;

  @media (min-height: 1px) and (max-height: 480px) {
    // iPhone 3, 4S
    width: $default-width * 0.95;
    height: $default-height * 0.95;
  }
  @media (min-height: 481px) and (max-height: 568px) {
    // iPhone 5, SE 1
    width: $default-width;
    height: $default-height;
  }
// 이 외 아이폰 사이즈들...
```
### 2️⃣ 공용 style의 쉬운 사용을 위해 _index.scss 생성
- @forward로 모든 공용 style 파일들 공유
```scss
//_index.scss
@forward 'colors.scss';
@forward 'fonts.scss';
@forward 'responsive.scss';
```
- 아래와 같이 사용하면 반응형 사이즈 사용 가능
```scss
// 사용할파일.scss
@use '경로/_index.scss' as *;

// mixin에 사용할 경우 
@mixin FollowButton($isActive: false) {
  @include responsive-dimensions(48px, 24px);
}

// class에 사용할 경우
.button {
  @include responsive-dimensions(48px, 24px);
}
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- [x] 모든 iPhone 사이즈에 대응할 수 있는지
- [x] '_index.scss'로 공통 스타일을 모두 사용할 수 있다는 것을 인지했는지

<br/>

## 발견한 이슈
없음
