### PR TITLE
✨ 액세스 토큰 추가

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist
 .eslintrc.cjs
 mocks
+index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: React.FC<React.SVGProps<SVGElement>>;
+  export default content;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,3 +2,9 @@ declare module '*.svg' {
   const content: React.FC<React.SVGProps<SVGElement>>;
   export default content;
 }
+
+export declare global {
+  interface Window {
+    setAccessToken: (accessToken: string) => void;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "axios": "^1.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "6.22.2"
+    "react-router-dom": "6.22.2",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.28.11",

--- a/src/app/webview/index.ts
+++ b/src/app/webview/index.ts
@@ -1,0 +1,5 @@
+import { setAccessToken } from '@/shared/store';
+
+export function initWebViewInfo() {
+  window.setAccessToken = setAccessToken;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom/client';
 
 import App from './app/App';
+import { initWebViewInfo } from './app/webview';
 
 async function enableMocking() {
   if (import.meta.env.PROD) {
@@ -13,5 +14,6 @@ async function enableMocking() {
 }
 
 enableMocking().then(() => {
+  initWebViewInfo();
   ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
 });

--- a/src/shared/store/auth/auth-store.ts
+++ b/src/shared/store/auth/auth-store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+interface AuthState {
+  accessToken: string | undefined;
+}
+
+const useAuthStore = create<AuthState>()(
+  devtools(
+    (): AuthState => ({
+      accessToken: undefined,
+    }),
+    { name: 'auth-store' },
+  ),
+);
+
+export function setAccessToken(accessToken: string) {
+  useAuthStore.setState(() => ({ accessToken }), false, 'auth/setAccessToken');
+}
+
+export function getAccessToken() {
+  return useAuthStore.getState().accessToken;
+}

--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -1,0 +1,1 @@
+export { setAccessToken, getAccessToken } from './auth/auth-store';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,6 @@
       "@public/*": ["public/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "index.d.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,11 +1677,6 @@ emoji-regex@^10.3.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.3.0.tgz#76998b9268409eb3dae3de989254d456e70cfe23"
   integrity sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==
 
-emoji-regex@^10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.3.0.tgz#76998b9268409eb3dae3de989254d456e70cfe23"
-  integrity sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -2775,16 +2770,6 @@ json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-"jsx-ast-utils@^2.4.1 || ^3.0.0":
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"
-  integrity sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==
-  dependencies:
-    array-includes "^3.1.6"
-    array.prototype.flat "^1.3.1"
-    object.assign "^4.1.4"
-    object.values "^1.1.6"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
@@ -4056,6 +4041,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 vite-node@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-1.5.0.tgz#7f74dadfecb15bca016c5ce5ef85e5cc4b82abf2"
@@ -4295,3 +4285,10 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+zustand@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.2.tgz#fddbe7cac1e71d45413b3682cdb47b48034c3848"
+  integrity sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
## 작업 이유

Swift에서 WebView 로드 시, 토큰을 클라이언트 상태에 저장하기 위함

<br/>

## 작업 사항

### 1️⃣  Zustand 라이브러리 설치

복잡한 전역 상태를 다루지 않기에 Zustand를 선택하여 설치하였습니다. Context API를 사용하지 않는 이유는 다음과 같습니다.

1. Context API를 사용하게 되면, Provider를 매번 추가해주어야 한다는 복잡성이 따른다.
2. 지금 전역 상태를 활용하는 부분에 대해 생각나는 부분이 Feed에 대한 상세 정보를 전역으로 관리하는 것이 있는데, 이 외에도 어떠한 정보를 전역으로 고민할 지 

### 2️⃣ AccessToken 등록

![image](https://github.com/CollaBu/pennyway-client-webview/assets/44726494/bcb1673b-2dd4-4b8d-a217-de248b02d1c4)

Swift에서 WebView를 화면에 표시하는 시나리오는 위와 같습니다. 우선 WebView를 로드하고, WebView에서는 정상적으로 로드되었다는 메시지를 전송하면 Swift에서 클라이언트단에 등록된 `window.setAccessToken` 메서드를 호출하여 액세스 토큰을 저장한다.

참고 문서: [Swift & React: WKWebView를 통해 iOS Native와 웹뷰 사이 통신하기](https://medium.com/hcleedev/swift-react-wkwebview%EB%A5%BC-%ED%86%B5%ED%95%B4-native%EC%99%80-%EC%9B%B9%EB%B7%B0-%EC%82%AC%EC%9D%B4-%ED%86%B5%EC%8B%A0%ED%95%98%EA%B8%B0-23f36984c5af)

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [x] Zustand를 사용하는 이유와 방법에 대해 인지했는지
- [x] Swift와 WebView 간의 통신 방법에 대해 이해했는지

<br/>

## 발견한 이슈

- 없음