### PR TITLE
🛠️ Basic, Active Button font 설정

### DIFF
--- a/src/shared/ui/button/ActiveButton.tsx
+++ b/src/shared/ui/button/ActiveButton.tsx
@@ -1,7 +1,10 @@
 import { ButtonProps } from './types';
 import './ActiveButton.scss';
 
-export type ActiveStyle = 'confirm' | 'follow-sm' | 'follow-lg';
+export type ActiveStyle =
+  | 'confirm h4semi'
+  | 'follow-sm b2semi'
+  | 'follow-lg b1semi';
 
 interface ActiveButtonProps extends ButtonProps {
   styleClass: ActiveStyle;

--- a/src/shared/ui/button/BasicButton.tsx
+++ b/src/shared/ui/button/BasicButton.tsx
@@ -3,9 +3,9 @@ import './BasicButton.scss';
 
 export type BasicStyle =
   | 'defalut'
-  | 'confirm-cancle'
-  | 'bsm-cancle'
-  | 'bsm-option';
+  | 'confirm-cancle h4semi'
+  | 'bsm-cancle h4semi'
+  | 'bsm-option h4md';
 
 interface BasicButtonProps extends ButtonProps {
   styleClass: BasicStyle;

--- a/src/shared/ui/modal/BottomSheetModal.tsx
+++ b/src/shared/ui/modal/BottomSheetModal.tsx
@@ -25,14 +25,17 @@ export const BottomSheetModal = ({
         <div className='modal-content'>
           {options.map((option, index) => (
             <Fragment key={index}>
-              <BasicButton onClick={option.onClick} styleClass='bsm-option'>
+              <BasicButton
+                onClick={option.onClick}
+                styleClass='bsm-option h4md'
+              >
                 {option.label}
               </BasicButton>
               {index < options.length - 1 && <hr className='option-divider' />}
             </Fragment>
           ))}
         </div>
-        <BasicButton styleClass='bsm-cancle' onClick={onClose}>
+        <BasicButton styleClass='bsm-cancle h4semi' onClick={onClose}>
           취소
         </BasicButton>
       </div>

--- a/src/shared/ui/modal/ConfirmModal.tsx
+++ b/src/shared/ui/modal/ConfirmModal.tsx
@@ -23,13 +23,13 @@ export const ConfirmModal = ({
         <h3 className='title h3semi'>{title}</h3>
         <p className='content b1md'>{content}</p>
         <div className='buttons'>
-          <BasicButton onClick={onClose} styleClass='confirm-cancle'>
+          <BasicButton onClick={onClose} styleClass='confirm-cancle h4semi'>
             {onCloseMsg}
           </BasicButton>
           <ActiveButton
             onClick={onExecute}
             isDisabled={onExecuteIsDisabled}
-            styleClass='confirm'
+            styleClass='confirm h4semi'
           >
             {onExecuteMsg}
           </ActiveButton>

--- a/src/shared/ui/modal/ConfirmReportModal.tsx
+++ b/src/shared/ui/modal/ConfirmReportModal.tsx
@@ -17,13 +17,13 @@ export const ConfirmReportModal = ({
         <h3 className='title h3semi'>{title}</h3>
         <section></section>
         <div className='buttons'>
-          <BasicButton onClick={onClose} styleClass='confirm-cancle'>
+          <BasicButton onClick={onClose} styleClass='confirm-cancle h4semi'>
             {onCloseMsg}
           </BasicButton>
           <ActiveButton
             onClick={onExecute}
             isDisabled={onExecuteIsDisabled}
-            styleClass='confirm'
+            styleClass='confirm h4semi'
           >
             {onExecuteMsg}
           </ActiveButton>


### PR DESCRIPTION
## 작업 이유
#32 Basic, Active 버튼 컴포넌트에 대한 폰트 설정 이슈 해결

<br/>

## 작업 사항
- styleClass prop에 font를 추가로 작성하도록 했습니다. 
```ts
//ActiveButton.tsx
export type ActiveStyle =
  | 'confirm h4semi'
  | 'follow-sm b2semi'
  | 'follow-lg b1semi';

//BasicButton.tsx
export type BasicStyle =
  | 'defalut'
  | 'confirm-cancle h4semi'
  | 'bsm-cancle h4semi'
  | 'bsm-option h4md';
```
#### 이 외 고려한 방식
- 입력받은 styleClass prop에 따라 분기 처리로 font를 적용하는 것
  - 추후 정의된 styleClass의 갯수가 늘어남에 따라 코드의 가독성이 떨어질 것으로 예측
- font prop을 추가로 내려받는 것
  - UI기획과 다른 font를 사용할 가능성이 생김, 중복된 prop을 작성해야 하는 번거로움

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- [x] 선언된 styleClass가 UI기획과 일치하는지

<br/>

## 발견한 이슈
X
