### PR TITLE
🛠️ fonts 디코딩 이슈 해결

### DIFF
--- a/src/app/styles/_fonts.scss
+++ b/src/app/styles/_fonts.scss
@@ -10,7 +10,6 @@
     src:
       url('/assets/font/pretendard-#{$weight}-subset.woff2') format('woff2'),
       url('/assets/font/pretendard-#{$weight}-subset.woff') format('woff');
-    font-weight: $weight;
     font-style: normal;
   }
 }

--- a/src/app/styles/_fonts.scss
+++ b/src/app/styles/_fonts.scss
@@ -1,6 +1,6 @@
-@mixin font-style($weight, $size, $line-height) {
+@mixin font-style($weight-number, $weight,  $size, $line-height) {
   font-family: 'Pretendard', sans-serif;
-  font-weight: $weight;
+  font-weight: $weight-number;
   font-size: $size * 1rem;
   letter-spacing: -0.03rem;
   line-height: $line-height;
@@ -16,32 +16,32 @@
 }
 
 /* 24px */
-.h1bold { @include font-style(700, 1.5, 31px); }
-.h1semi { @include font-style(600, 1.5, 31px); }
+.h1bold { @include font-style(700, 'bold', 1.5, 31px); }
+.h1semi { @include font-style(600, 'semibold', 1.5, 31px); }
 
 /* 20px */
-.h2semi { @include font-style(600, 1.25, 26px); }
+.h2semi { @include font-style(600, 'semibold', 1.25, 26px); }
 
 /* 16px */
-.h3bold { @include font-style(700, 1, 22px); }
-.h3semi { @include font-style(600, 1, 22px); }
+.h3bold { @include font-style(700, 'bold', 1, 22px); }
+.h3semi { @include font-style(600, 'semibold', 1, 22px); }
 
 /* 14px */
-.h4semi { @include font-style(600, 0.875, 18px); }
-.h4md { @include font-style(500, 0.875, 18px); }
+.h4semi { @include font-style(600, 'semibold', 0.875, 18px); }
+.h4md { @include font-style(500, 'medium', 0.875, 18px); }
 
 /* 12px */
-.b1semi { @include font-style(600, 0.75, 16px); }
-.b1md { @include font-style(500, 0.75, 16px); }
-.b1reg { @include font-style(400, 0.75, 17px); }
+.b1semi { @include font-style(600, 'semibold', 0.75, 16px); }
+.b1md { @include font-style(500, 'medium', 0.75, 16px); }
+.b1reg { @include font-style(400, 'regular', 0.75, 17px); }
 
 /* 11px */
-.b2md { @include font-style(500, 0.6875, 14px); }
-.b2semi { @include font-style(600, 0.6875, 14px); }
-.b2reg { @include font-style(400, 0.6875, 14px); }
+.b2md { @include font-style(500, 'medium', 0.6875, 14px); }
+.b2semi { @include font-style(600, 'semibold', 0.6875, 14px); }
+.b2reg { @include font-style(400, 'regular', 0.6875, 14px); }
 
 /* 9px */
-.b3md { @include font-style(500, 0.5625, 12px); }
+.b3md { @include font-style(500, 'medium', 0.5625, 12px); }
 
 /* 8px */
-.b4md { @include font-style(500, 0.5, 10px); }
+.b4md { @include font-style(500, 'medium', 0.5, 10px); }


### PR DESCRIPTION
## 작업 이유
#36  fonts 디코딩 이슈 해결

<br/>

## 작업 사항
- weight를 숫자로 변경하며 font file을 정상적으로 불러오지 못했습니다.
```scss
@mixin font-style($weight, $size, $line-height) {
  font-weight: $weight;
//...
  @font-face {
    font-family: 'Pretendard';
    src:
      url('/assets/font/pretendard-#{$weight}-subset.woff2') format('woff2'), 
      url('/assets/font/pretendard-#{$weight}-subset.woff') format('woff');
  }
}

.h1bold { @include font-style(700, 1.5, 31px); } //$weight에 숫자가 들어가며 에러 발생
```
- 숫자는 weight-number, url 링크에 들어갈 단어는 weight로 둘 다 병기하도록 처리했습니다.
```scss
@mixin font-style($weight-number, $weight, $size, $line-height) {
  font-weight: $weight-number;
//...
.h1bold { @include font-style(700, 'bold', 1.5, 31px); }
```
![image](https://github.com/CollaBu/pennyway-client-webview/assets/101088491/0749b116-d42b-4da0-a703-d7feb6482a88)

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- [x] 정상적으로 font를 불러오고 있나요?

<br/>

## 발견한 이슈
x
