### PR TITLE
🛠️ 피드 메인 페이지 피드백 반영

### DIFF
--- a/src/app/mocks/handler/feed.ts
+++ b/src/app/mocks/handler/feed.ts
@@ -1,4 +1,4 @@
-import { http } from 'msw';
+import { delay, http } from 'msw';
 
 import { feeds } from '../consts/feed';
 import { reports } from '../consts/report';
@@ -28,7 +28,7 @@ export const feedHandlers = [
   /**
    * @todo pageCount를 쿼리 파라미터로 받도록 수정
    */
-  http.get('/feeds', ({ request }) => {
+  http.get('/feeds', async ({ request }) => {
     const url = new URL(request.url);
     const page = url.searchParams.get('page') || 1;
 
@@ -46,6 +46,8 @@ export const feedHandlers = [
     const totalFeeds = Object.values(feeds).length;
     const endOfPageRange = formattedPage * pageCount;
     const hasNextPage = endOfPageRange < totalFeeds;
+
+    await delay(Math.floor(Math.random() * (4000 - 2000 + 1)) + 2000);
 
     return createHttpSuccessResponse({
       feeds: feedsData,

--- a/src/app/providers/query-client.ts
+++ b/src/app/providers/query-client.ts
@@ -6,6 +6,7 @@ const queryClientOptions: QueryClientConfig = {
       staleTime: 10 * 60 * 1000, // 10 minutes
       gcTime: 15 * 60 * 1000, // 15 minutes
       refetchOnWindowFocus: false,
+      retry: false,
     },
   },
 };

--- a/src/pages/feed-main/ui/FeedMainPage.scss
+++ b/src/pages/feed-main/ui/FeedMainPage.scss
@@ -1,0 +1,3 @@
+.feed-main-page {
+  margin-bottom: 24px;
+}

--- a/src/pages/feed-main/ui/FeedMainPage.tsx
+++ b/src/pages/feed-main/ui/FeedMainPage.tsx
@@ -1,4 +1,5 @@
 import { FeedMainHeader, FeedMainList } from '@/widgets';
+import './FeedMainPage.scss';
 
 export const FeedMainPage = () => {
   return (

--- a/src/shared/axios/config/instance.ts
+++ b/src/shared/axios/config/instance.ts
@@ -4,7 +4,7 @@ import { onError, onRequest, onResponse } from './interceptors';
 
 export const axiosInstance = axios.create({
   baseURL: '',
-  timeout: 5000,
+  timeout: 3000,
   headers: {
     'Content-Type': 'application/json; charset=utf-8',
   },

--- a/src/shared/ui/network-toast-error/NetworkToastError.scss
+++ b/src/shared/ui/network-toast-error/NetworkToastError.scss
@@ -1,75 +1,35 @@
-@keyframes bounceInUp {
-  from,
-  60%,
-  75%,
-  90%,
-  to {
-    animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
-  }
-  from {
-    opacity: 0;
-    transform: translate3d(0, 100%, 0);
-  }
-  60% {
-    opacity: 1;
-    transform: translate3d(0, -20px, 0);
-  }
-  75% {
-    transform: translate3d(0, 10px, 0);
-  }
-  90% {
-    transform: translate3d(0, -5px, 0);
-  }
-  to {
-    transform: translate3d(0, 0, 0);
-  }
-}
+.Toastify__toast-container {
+  width: 100%;
+  margin-bottom: 8px;
 
-.Toastify {
-  position: fixed;
-  bottom: 8px;
-  left: 0;
-  right: 0;
+  .Toastify__toast {
+    font-family: unset;
 
-  width: 280px;
-  height: 40px;
-  margin: 0 auto;
+    margin: 0 auto;
+    width: 280px;
+    height: 40px;
 
-  .network-error-toast {
-    animation: bounceInUp 0.75s cubic-bezier(0.68, -0.55, 0.27, 1.55) both;
+    min-height: 40px;
+    max-height: 40px;
 
-    width: 100%;
-    height: 100%;
     border-radius: 6px;
 
-    display: flex;
-    align-items: center;
-
-    color: #ffffff;
     background: #98a3b4e5;
+    color: #ffffff;
+    padding: 0;
 
-    .Toastify__toast--default {
-      color: #ffffff;
+    .Toastify__toast-body {
+      height: 40px;
+      padding: 0 0 0 12px;
 
-      width: 100%;
-
-      .Toastify__toast-body {
-        display: flex;
-        align-items: center;
-
-        gap: 6px;
-
-        .Toastify__toast-icon {
-          width: 20px;
-          height: 20px;
-
-          margin-left: 12px;
-        }
+      .Toastify__toast-icon {
+        margin-inline-end: 6px;
       }
+    }
 
-      .Toastify__close-button {
-        display: none;
-      }
+    .Toastify__close-button,
+    .Toastify__progress-bar--wrp {
+      display: none;
     }
   }
 }

--- a/src/shared/ui/network-toast-error/NetworkToastError.tsx
+++ b/src/shared/ui/network-toast-error/NetworkToastError.tsx
@@ -1,9 +1,32 @@
-import { ToastContainer } from 'react-toastify';
+import { useEffect, useRef } from 'react';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 import './NetworkToastError.scss';
 import { Icon } from '..';
 
-export const NetworkToastError = () => {
+interface NetworkToastErrorProps {
+  isVisible: boolean;
+  errorMessage: string;
+}
+
+export const NetworkToastError: React.FC<NetworkToastErrorProps> = ({
+  isVisible,
+  errorMessage,
+}) => {
+  const toastId = useRef<number | string>(-1);
+
+  useEffect(() => {
+    if (isVisible && toastId.current === -1) {
+      toastId.current = toast(errorMessage);
+    }
+
+    if (!isVisible && toastId.current !== -1) {
+      toast.dismiss(toastId.current);
+      toastId.current = -1;
+    }
+  }, [isVisible, errorMessage]);
+
   return (
     <ToastContainer
       className='network-error-toast b1semi'

--- a/src/shared/ui/network-toast-error/NetworkToastError.tsx
+++ b/src/shared/ui/network-toast-error/NetworkToastError.tsx
@@ -19,11 +19,13 @@ export const NetworkToastError: React.FC<NetworkToastErrorProps> = ({
   useEffect(() => {
     if (isVisible && toastId.current === -1) {
       toastId.current = toast(errorMessage);
+      return;
     }
 
     if (!isVisible && toastId.current !== -1) {
       toast.dismiss(toastId.current);
       toastId.current = -1;
+      return;
     }
   }, [isVisible, errorMessage]);
 

--- a/src/widgets/feed-main-list/ui/FeedMainList.scss
+++ b/src/widgets/feed-main-list/ui/FeedMainList.scss
@@ -1,6 +1,6 @@
 .feed-list-section {
   .feed-list {
-    padding: 16px 0 24px;
+    margin-top: 16px;
   }
 
   .feed-wrapper:not(:last-child)::after {

--- a/src/widgets/feed-main-list/ui/FeedMainList.tsx
+++ b/src/widgets/feed-main-list/ui/FeedMainList.tsx
@@ -1,5 +1,4 @@
 import InfiniteScroll from 'react-infinite-scroller';
-import { toast } from 'react-toastify';
 
 import { NetworkError, NetworkToastError } from '@/shared/ui';
 
@@ -29,11 +28,6 @@ export const FeedMainList = () => {
     return <NetworkError refetch={refetchFeeds} />;
   }
 
-  if (isError && feeds) {
-    // 무한 스크롤 도중 에러가 발생할 경우
-    toast('인터넷 연결이 불안정해요');
-  }
-
   return (
     <section className='feed-list-section'>
       <InfiniteScroll
@@ -50,7 +44,10 @@ export const FeedMainList = () => {
         })}
         {isFetching && <SkeletonFeedMainList count={3} />}
       </InfiniteScroll>
-      <NetworkToastError />
+      <NetworkToastError
+        isVisible={isError && !!feeds}
+        errorMessage='인터넷 연결이 불안정해요'
+      />
     </section>
   );
 };

--- a/src/widgets/feed-main-list/ui/FeedMainList.tsx
+++ b/src/widgets/feed-main-list/ui/FeedMainList.tsx
@@ -21,7 +21,7 @@ export const FeedMainList = () => {
   } = useInfinityFeeds();
 
   if (isLoading) {
-    return <SkeletonFeedMainList />;
+    return <SkeletonFeedMainList count={10} />;
   }
 
   if (isError && !feeds) {
@@ -48,7 +48,7 @@ export const FeedMainList = () => {
             <Feed key={feed.id} feed={feed} />
           ));
         })}
-        {isFetching && <SkeletonFeedMainList />}
+        {isFetching && <SkeletonFeedMainList count={3} />}
       </InfiniteScroll>
       <NetworkToastError />
     </section>

--- a/src/widgets/feed-main-list/ui/FeedMainList.tsx
+++ b/src/widgets/feed-main-list/ui/FeedMainList.tsx
@@ -48,6 +48,7 @@ export const FeedMainList = () => {
             <Feed key={feed.id} feed={feed} />
           ));
         })}
+        {isFetching && <SkeletonFeedMainList />}
       </InfiniteScroll>
       <NetworkToastError />
     </section>

--- a/src/widgets/feed-main-list/ui/SkeletonFeedMainList.scss
+++ b/src/widgets/feed-main-list/ui/SkeletonFeedMainList.scss
@@ -1,9 +1,5 @@
 .skeleton-feed-section {
-  width: 320px;
-  height: 508px;
-  margin: 16px 0 24px;
-
-  overflow: hidden;
+  margin-top: 16px;
 
   .skeleton-feed-wrapper:not(:last-child)::after {
     content: '';

--- a/src/widgets/feed-main-list/ui/SkeletonFeedMainList.tsx
+++ b/src/widgets/feed-main-list/ui/SkeletonFeedMainList.tsx
@@ -1,10 +1,12 @@
 import { SkeletonFeed } from './SkeletonFeed';
 import './SkeletonFeedMainList.scss';
 
-export const SkeletonFeedMainList = () => {
+export const SkeletonFeedMainList: React.FC<{ count: number }> = ({
+  count,
+}) => {
   return (
     <section className='skeleton-feed-section'>
-      {new Array(10).fill(1).map((_, i) => (
+      {new Array(count).fill(1).map((_, i) => (
         <SkeletonFeed key={i} />
       ))}
     </section>

--- a/src/widgets/feed-main-list/ui/SkeletonFeedMainList.tsx
+++ b/src/widgets/feed-main-list/ui/SkeletonFeedMainList.tsx
@@ -4,7 +4,7 @@ import './SkeletonFeedMainList.scss';
 export const SkeletonFeedMainList = () => {
   return (
     <section className='skeleton-feed-section'>
-      {new Array(5).fill(1).map((_, i) => (
+      {new Array(10).fill(1).map((_, i) => (
         <SkeletonFeed key={i} />
       ))}
     </section>


### PR DESCRIPTION
## 작업 이유

- 피드 메인 페이지 피드백 반영

<br/>

## 작업 사항

### 1️⃣ 피드 메인 페이지 스크롤

<div align="center">
<img src="https://github.com/CollaBu/pennyway-client-webview/assets/44726494/2096dc6b-700d-45bc-9759-62cf00c24fa7" height="360" />
</div>

피드 메인 페이지에서 스크롤 되는 것은 웹 상에서 기본적으로 제공해주는 기능으로, Mobile로 확인했을 때에는 스크롤이 표시되지 않는 것으로 확인되었습니다!

그래서 우선, 따로 처리해두지 않았는데 만약 iOS에서 WebView를 load했을 때 스크롤이 표시된다면 따로 처리하겠습니다.

### 2️⃣ 피드 메인 페이지에서 스크롤 시 2 페이지부터 스켈레톤 UI가 표시되지 않는 문제

초기 로딩 시 스켈레톤 UI를 10개 보여주고, 이후에 2페이지부터는 스켈레톤 UI를 3개씩 보여주도록 설정하였습니다.

### 3️⃣ 피드 메인 페이지 시나리오 추가

실제 환경과 동일한 환경을 구성하기 위해 Feed 무한 스크롤 시 API 응답 시간을 임의로 2 ~ 4초로 설정하고, 클라이언트측에서는 API Timeout을 3초로 설정하였습니다.

네트워크 에러 토스트 메시지의 경우에는 API 에러가 발생할 경우 표시되고, 다시 API 요청이 정상적으로 처리되면 사라지게 하였습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [x] 스켈레톤 UI가 초기 로딩과 다음 페이지를 요청할 때도 정상적으로 표시되고 있나요?
- [x] 네트워크 에러 토스트 메시지가 정상적으로 표시되고, 사라지나요?
- [x] 이 외에 혹시 제가 확인하지 못한 부분이 있을까요?

<br/>

## 발견한 이슈

- 폰트 디코딩과 관련한 이슈가 있어, 의찬님께서 이를 이슈로 등록하였습니다. - #36 