### PR TITLE
✨ 피드 북마크 API 연동

### DIFF
--- a/src/app/mocks/browser.ts
+++ b/src/app/mocks/browser.ts
@@ -6,11 +6,13 @@ import { likeHandlers } from './handler/like';
 import { followHandler } from './handler/follow';
 import { searchHandler } from './handler/search';
 import { userHandler } from './handler/user';
+import { bookmarkHandlers } from './handler/bookmark';
 
 // 브라우저에서 실행하기 위한 mocking worker 초기화
 export const worker = setupWorker(
   ...commentHandlers,
   ...feedHandlers,
+  ...bookmarkHandlers,
   ...likeHandlers,
   ...followHandler,
   ...searchHandler,

--- a/src/app/mocks/consts/feed.ts
+++ b/src/app/mocks/consts/feed.ts
@@ -61,7 +61,7 @@ export const feeds: Feeds = {
     commentCount: comments[1].length,
 
     isLiked: likes[1].isLiked,
-    isBookmark: true,
+    isBookmarked: true,
 
     createdAt: '2024-04-16 12:00:00',
     updatedAt: '2024-04-16 12:00:00',
@@ -76,7 +76,7 @@ export const feeds: Feeds = {
     commentCount: comments[2].length,
 
     isLiked: likes[2].isLiked,
-    isBookmark: false,
+    isBookmarked: false,
 
     createdAt: '2024-04-16 12:10:00',
     updatedAt: '2024-04-16 12:10:00',
@@ -104,7 +104,7 @@ export const feeds: Feeds = {
     commentCount: comments[3].length,
 
     isLiked: likes[3].isLiked,
-    isBookmark: true,
+    isBookmarked: true,
 
     createdAt: '2024-04-16 12:20:00',
     updatedAt: '2024-04-16 12:20:00',
@@ -140,7 +140,7 @@ export const feeds: Feeds = {
     commentCount: comments[4].length,
 
     isLiked: likes[4].isLiked,
-    isBookmark: false,
+    isBookmarked: false,
 
     createdAt: '2024-04-16 12:30:00',
     updatedAt: '2024-04-16 12:30:00',
@@ -168,7 +168,7 @@ export const feeds: Feeds = {
     commentCount: comments[5].length,
 
     isLiked: likes[5].isLiked,
-    isBookmark: false,
+    isBookmarked: false,
 
     createdAt: '2024-04-16 12:40:00',
     updatedAt: '2024-04-16 12:40:00',
@@ -196,7 +196,7 @@ export const feeds: Feeds = {
     commentCount: comments[6].length,
 
     isLiked: likes[6].isLiked,
-    isBookmark: false,
+    isBookmarked: false,
 
     createdAt: '2024-04-16 12:50:00',
     updatedAt: '2024-04-16 12:50:00',
@@ -220,7 +220,7 @@ export const feeds: Feeds = {
     commentCount: comments[7].length,
 
     isLiked: likes[7].isLiked,
-    isBookmark: false,
+    isBookmarked: false,
 
     createdAt: '2024-04-16 13:00:00',
     updatedAt: '2024-04-16 13:00:00',
@@ -240,7 +240,7 @@ export const feeds: Feeds = {
     commentCount: comments[8].length,
 
     isLiked: likes[8].isLiked,
-    isBookmark: false,
+    isBookmarked: false,
 
     createdAt: '2024-04-16 13:10:00',
     updatedAt: '2024-04-16 13:10:00',
@@ -264,7 +264,7 @@ export const feeds: Feeds = {
     commentCount: comments[9].length,
 
     isLiked: likes[9].isLiked,
-    isBookmark: false,
+    isBookmarked: false,
 
     createdAt: '2024-04-16 13:20:00',
     updatedAt: '2024-04-16 13:20:00',
@@ -285,7 +285,7 @@ for (let i = 10; i < 100; i++) {
     commentCount: comments[i].length,
 
     isLiked: likes[i].isLiked,
-    isBookmark: false,
+    isBookmarked: false,
 
     createdAt: '2024-05-03 12:00:00',
     updatedAt: '2024-05-03 12:00:00',

--- a/src/app/mocks/consts/feed.ts
+++ b/src/app/mocks/consts/feed.ts
@@ -61,7 +61,7 @@ export const feeds: Feeds = {
     commentCount: comments[1].length,
 
     isLiked: likes[1].isLiked,
-    isBookmark: false,
+    isBookmark: true,
 
     createdAt: '2024-04-16 12:00:00',
     updatedAt: '2024-04-16 12:00:00',
@@ -104,7 +104,7 @@ export const feeds: Feeds = {
     commentCount: comments[3].length,
 
     isLiked: likes[3].isLiked,
-    isBookmark: false,
+    isBookmark: true,
 
     createdAt: '2024-04-16 12:20:00',
     updatedAt: '2024-04-16 12:20:00',

--- a/src/app/mocks/handler/bookmark.ts
+++ b/src/app/mocks/handler/bookmark.ts
@@ -1,0 +1,47 @@
+import { http } from 'msw';
+
+import {
+  createHttpErrorResponse,
+  createHttpSuccessResponse,
+} from '../dir/response';
+import { feeds } from '../consts/feed';
+
+export const bookmarkHandlers = [
+  // 1️⃣ 피드 북마크
+  http.put('/feeds/:feed_id/bookmarks', ({ params }) => {
+    const { feed_id } = params;
+
+    if (isNaN(Number(feed_id))) {
+      return createHttpErrorResponse('4220');
+    }
+
+    const formattedFeedId = Number(feed_id);
+
+    if (!feeds[formattedFeedId]) {
+      return createHttpErrorResponse('4040');
+    }
+
+    feeds[formattedFeedId].isBookmarked = true;
+
+    return createHttpSuccessResponse({ isBookmarked: true });
+  }),
+
+  // 2️⃣ 피드 북마크 취소
+  http.delete('/feeds/:feed_id/likes', ({ params }) => {
+    const { feed_id } = params;
+
+    if (isNaN(Number(feed_id))) {
+      return createHttpErrorResponse('4220');
+    }
+
+    const formattedFeedId = Number(feed_id);
+
+    if (!feeds[formattedFeedId]) {
+      return createHttpErrorResponse('4040');
+    }
+
+    feeds[formattedFeedId].isBookmarked = false;
+
+    return createHttpSuccessResponse({ isBookmarked: false });
+  }),
+];

--- a/src/app/mocks/handler/bookmark.ts
+++ b/src/app/mocks/handler/bookmark.ts
@@ -27,7 +27,7 @@ export const bookmarkHandlers = [
   }),
 
   // 2️⃣ 피드 북마크 취소
-  http.delete('/feeds/:feed_id/likes', ({ params }) => {
+  http.delete('/feeds/:feed_id/bookmarks', ({ params }) => {
     const { feed_id } = params;
 
     if (isNaN(Number(feed_id))) {

--- a/src/app/mocks/handler/feed.ts
+++ b/src/app/mocks/handler/feed.ts
@@ -77,7 +77,7 @@ export const feedHandlers = [
       commentCount: 0,
 
       isLiked: false,
-      isBookmark: false,
+      isBookmarked: false,
 
       createdAt: getCurrentDate(),
       updatedAt: getCurrentDate(),
@@ -205,10 +205,10 @@ export const feedHandlers = [
       return createHttpErrorResponse('4040');
     }
 
-    feeds[formattedFeedId].isBookmark = !feeds[formattedFeedId].isBookmark;
+    feeds[formattedFeedId].isBookmarked = !feeds[formattedFeedId].isBookmarked;
 
     return createHttpSuccessResponse({
-      isBookmarked: feeds[formattedFeedId].isBookmark,
+      isBookmarked: feeds[formattedFeedId].isBookmarked,
     });
   }),
 ];

--- a/src/app/mocks/handler/feed.ts
+++ b/src/app/mocks/handler/feed.ts
@@ -190,4 +190,25 @@ export const feedHandlers = [
 
     return createHttpSuccessResponse({});
   }),
+
+  // 7️⃣ 피드 북마크
+  http.put('/feeds/:feed_id/bookmarks', ({ params }) => {
+    const { feed_id } = params;
+
+    if (isNaN(Number(feed_id))) {
+      return createHttpErrorResponse('4220');
+    }
+
+    const formattedFeedId = Number(feed_id);
+
+    if (!feeds[formattedFeedId]) {
+      return createHttpErrorResponse('4040');
+    }
+
+    feeds[formattedFeedId].isBookmark = !feeds[formattedFeedId].isBookmark;
+
+    return createHttpSuccessResponse({
+      isBookmarked: feeds[formattedFeedId].isBookmark,
+    });
+  }),
 ];

--- a/src/app/mocks/handler/feed.ts
+++ b/src/app/mocks/handler/feed.ts
@@ -25,9 +25,6 @@ interface ReportForm {
 
 export const feedHandlers = [
   // 1️⃣ 피드 목록 조회
-  /**
-   * @todo pageCount를 쿼리 파라미터로 받도록 수정
-   */
   http.get('/feeds', ({ request }) => {
     const url = new URL(request.url);
     const page = url.searchParams.get('page') || 1;
@@ -189,26 +186,5 @@ export const feedHandlers = [
     }
 
     return createHttpSuccessResponse({});
-  }),
-
-  // 7️⃣ 피드 북마크
-  http.put('/feeds/:feed_id/bookmarks', ({ params }) => {
-    const { feed_id } = params;
-
-    if (isNaN(Number(feed_id))) {
-      return createHttpErrorResponse('4220');
-    }
-
-    const formattedFeedId = Number(feed_id);
-
-    if (!feeds[formattedFeedId]) {
-      return createHttpErrorResponse('4040');
-    }
-
-    feeds[formattedFeedId].isBookmarked = !feeds[formattedFeedId].isBookmarked;
-
-    return createHttpSuccessResponse({
-      isBookmarked: feeds[formattedFeedId].isBookmarked,
-    });
   }),
 ];

--- a/src/features/feed-bookmark/api/index.ts
+++ b/src/features/feed-bookmark/api/index.ts
@@ -1,0 +1,1 @@
+export { useBookmark } from './useBookmark';

--- a/src/features/feed-bookmark/api/index.ts
+++ b/src/features/feed-bookmark/api/index.ts
@@ -1,1 +1,1 @@
-export { useBookmark } from './useBookmark';
+export { useBookmarks } from './useBookmarks';

--- a/src/features/feed-bookmark/api/useBookmark.tsx
+++ b/src/features/feed-bookmark/api/useBookmark.tsx
@@ -1,0 +1,58 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { axiosInstance } from '@/shared/axios';
+import { FeedsQueryData } from '@/shared/consts';
+import { QUERY_KEYS } from '@/shared/react-query';
+import { isErrorResponse } from '@/shared/utils';
+
+import { updateBookmarkStatusInFeeds } from '../lib';
+
+async function requestBookmarkFeed(feedId: number) {
+  const { data } = await axiosInstance.put(`/feeds/${feedId}/bookmarks`);
+
+  return data;
+}
+
+export const useBookmark = (feedId: number) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: handleBookmarkFeed, isPending } = useMutation({
+    mutationFn: () => requestBookmarkFeed(feedId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: [QUERY_KEYS.feeds],
+      });
+
+      // 이전 쿼리값의 스냅샷
+      const previousQueryData = queryClient.getQueryData<FeedsQueryData>([
+        QUERY_KEYS.feeds,
+      ]);
+
+      if (!previousQueryData) return;
+
+      // 업데이트 될 쿼리값
+      const updatedQueryData = updateBookmarkStatusInFeeds(
+        previousQueryData,
+        feedId,
+      );
+
+      // setQueryData 함수를 사용해 newTodo로 Optimistic Update를 실시한다.
+      await queryClient.setQueryData([QUERY_KEYS.feeds], updatedQueryData);
+
+      return { previousQueryData };
+    },
+    onError: (_, __, context) => {
+      queryClient.setQueryData([QUERY_KEYS.feeds], context?.previousQueryData);
+    },
+    onSuccess: (response, _, context) => {
+      if (isErrorResponse(response)) {
+        queryClient.setQueryData([QUERY_KEYS.feeds], context.previousQueryData);
+        return;
+      }
+
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.feed, feedId] });
+    },
+  });
+
+  return { handleBookmarkFeed, isPending };
+};

--- a/src/features/feed-bookmark/api/useBookmarks.tsx
+++ b/src/features/feed-bookmark/api/useBookmarks.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { requestBookmarkFeed, requestUnBookmarkFeed } from '@/shared/axios';
+import { requestBookmarkFeed, requestUnbookmarkFeed } from '@/shared/axios';
 import { FeedsQueryData } from '@/shared/consts';
 import { QUERY_KEYS } from '@/shared/react-query';
 import { isErrorResponse } from '@/shared/utils';
@@ -13,7 +13,7 @@ export const useBookmarks = (feedId: number, isBookmarked: boolean) => {
   const { mutate: handleBookmarkFeed, isPending } = useMutation({
     mutationFn: () =>
       isBookmarked
-        ? requestUnBookmarkFeed(feedId)
+        ? requestUnbookmarkFeed(feedId)
         : requestBookmarkFeed(feedId),
     onMutate: async () => {
       await queryClient.cancelQueries({

--- a/src/features/feed-bookmark/api/useBookmarks.tsx
+++ b/src/features/feed-bookmark/api/useBookmarks.tsx
@@ -1,17 +1,20 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { requestBookmarkFeed } from '@/shared/axios';
+import { requestBookmarkFeed, requestUnBookmarkFeed } from '@/shared/axios';
 import { FeedsQueryData } from '@/shared/consts';
 import { QUERY_KEYS } from '@/shared/react-query';
 import { isErrorResponse } from '@/shared/utils';
 
 import { updateBookmarkStatusInFeeds } from '../lib';
 
-export const useBookmarks = (feedId: number) => {
+export const useBookmarks = (feedId: number, isBookmarked: boolean) => {
   const queryClient = useQueryClient();
 
   const { mutate: handleBookmarkFeed, isPending } = useMutation({
-    mutationFn: () => requestBookmarkFeed(feedId),
+    mutationFn: () =>
+      isBookmarked
+        ? requestUnBookmarkFeed(feedId)
+        : requestBookmarkFeed(feedId),
     onMutate: async () => {
       await queryClient.cancelQueries({
         queryKey: [QUERY_KEYS.feeds],

--- a/src/features/feed-bookmark/api/useBookmarks.tsx
+++ b/src/features/feed-bookmark/api/useBookmarks.tsx
@@ -1,17 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { axiosInstance } from '@/shared/axios';
+import { requestBookmarkFeed } from '@/shared/axios';
 import { FeedsQueryData } from '@/shared/consts';
 import { QUERY_KEYS } from '@/shared/react-query';
 import { isErrorResponse } from '@/shared/utils';
 
 import { updateBookmarkStatusInFeeds } from '../lib';
-
-async function requestBookmarkFeed(feedId: number) {
-  const { data } = await axiosInstance.put(`/feeds/${feedId}/bookmarks`);
-
-  return data;
-}
 
 export const useBookmarks = (feedId: number) => {
   const queryClient = useQueryClient();

--- a/src/features/feed-bookmark/api/useBookmarks.tsx
+++ b/src/features/feed-bookmark/api/useBookmarks.tsx
@@ -13,7 +13,7 @@ async function requestBookmarkFeed(feedId: number) {
   return data;
 }
 
-export const useBookmark = (feedId: number) => {
+export const useBookmarks = (feedId: number) => {
   const queryClient = useQueryClient();
 
   const { mutate: handleBookmarkFeed, isPending } = useMutation({

--- a/src/features/feed-bookmark/index.ts
+++ b/src/features/feed-bookmark/index.ts
@@ -1,0 +1,1 @@
+export { BookmarkButton } from './ui';

--- a/src/features/feed-bookmark/lib/index.ts
+++ b/src/features/feed-bookmark/lib/index.ts
@@ -1,0 +1,26 @@
+import { FeedsQueryData } from '@/shared/consts';
+
+export function updateBookmarkStatusInFeeds(
+  previousQueryData: FeedsQueryData,
+  feedId: number,
+) {
+  const { pages: previousPages } = previousQueryData;
+
+  return {
+    ...previousQueryData,
+    pages: previousPages.map((pageData) => {
+      const { data } = pageData;
+      const updateFeeds = data.feeds.map((feed) =>
+        feed.id === feedId
+          ? {
+              ...feed,
+              isBookmarked: !feed.isBookmarked,
+            }
+          : feed,
+      );
+      const updatedData = { ...data, feeds: updateFeeds };
+
+      return { ...pageData, data: updatedData };
+    }),
+  };
+}

--- a/src/features/feed-bookmark/test/useBookmarks.test.tsx
+++ b/src/features/feed-bookmark/test/useBookmarks.test.tsx
@@ -8,13 +8,13 @@ import { useBookmarks } from '../api';
 
 test('북마크 상태가 아닐 때, 북마크 버튼을 클릭하면 북마크 요청이 발생한다.', async () => {
   // given
-  // requestLikeFeed 함수를 스파이한다.
+  // requestBookmarkFeed 함수를 스파이한다.
   const spy = vi.spyOn(bookmarkModule, 'requestBookmarkFeed');
   const { result } = renderHook(() => useBookmarks(1, false), {
     wrapper: createQueryClientWrapper(),
   });
 
-  // requestLikeFeed가 호출되지 않았는지 확인
+  // requestBookmarkFeed가 호출되지 않았는지 확인
   await waitFor(() => expect(spy).not.toHaveBeenCalled());
 
   // when
@@ -22,7 +22,7 @@ test('북마크 상태가 아닐 때, 북마크 버튼을 클릭하면 북마크
   await act(async () => result.current.handleBookmarkFeed());
 
   // then
-  // requestLikeFeed가 호출되었는지 확인
+  // requestBookmarkFeed가 호출되었는지 확인
   await waitFor(() => expect(spy).toHaveBeenCalled());
 });
 

--- a/src/features/feed-bookmark/test/useBookmarks.test.tsx
+++ b/src/features/feed-bookmark/test/useBookmarks.test.tsx
@@ -1,0 +1,43 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+
+import * as bookmarkModule from '@/shared/axios';
+import { createQueryClientWrapper } from '@/shared/tests';
+
+import { useBookmarks } from '../api';
+
+test('북마크 상태가 아닐 때, 북마크 버튼을 클릭하면 북마크 요청이 발생한다.', async () => {
+  // given
+  // requestLikeFeed 함수를 스파이한다.
+  const spy = vi.spyOn(bookmarkModule, 'requestBookmarkFeed');
+  const { result } = renderHook(() => useBookmarks(1, false), {
+    wrapper: createQueryClientWrapper(),
+  });
+
+  // requestLikeFeed가 호출되지 않았는지 확인
+  await waitFor(() => expect(spy).not.toHaveBeenCalled());
+
+  // when
+  // 좋아요 버튼 클릭
+  await act(async () => result.current.handleBookmarkFeed());
+
+  // then
+  // requestLikeFeed가 호출되었는지 확인
+  await waitFor(() => expect(spy).toHaveBeenCalled());
+});
+
+test('북마크 상태일 때, 북마크 버튼을 클릭하면 북마크 취소 요청이 발생한다.', async () => {
+  // given
+  const spy = vi.spyOn(bookmarkModule, 'requestUnbookmarkFeed');
+  const { result } = renderHook(() => useBookmarks(1, true), {
+    wrapper: createQueryClientWrapper(),
+  });
+
+  await waitFor(() => expect(spy).not.toHaveBeenCalled());
+
+  // when
+  await act(async () => result.current.handleBookmarkFeed());
+
+  // then
+  await waitFor(() => expect(spy).toHaveBeenCalled());
+});

--- a/src/features/feed-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/feed-bookmark/ui/BookmarkButton.tsx
@@ -1,7 +1,7 @@
 import { ICON_ACTIVE_COLOR } from '@/shared/consts';
 import { Icon } from '@/shared/ui';
 
-import { useBookmark } from '../api/useBookmark';
+import { useBookmark } from '../api';
 
 interface BookmarkButtonProps {
   feedId: number;

--- a/src/features/feed-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/feed-bookmark/ui/BookmarkButton.tsx
@@ -1,0 +1,22 @@
+import { ICON_ACTIVE_COLOR } from '@/shared/consts';
+import { Icon } from '@/shared/ui';
+
+interface BookmarkButtonProps {
+  feedId: number;
+  isBookmark: boolean;
+}
+
+export const BookmarkButton: React.FC<BookmarkButtonProps> = ({
+  isBookmark,
+}) => {
+  return (
+    <button className='icon icon-btn'>
+      <Icon
+        name='bookmark'
+        width='20'
+        height='20'
+        color={isBookmark ? ICON_ACTIVE_COLOR : 'none'}
+      />
+    </button>
+  );
+};

--- a/src/features/feed-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/feed-bookmark/ui/BookmarkButton.tsx
@@ -1,7 +1,7 @@
 import { ICON_ACTIVE_COLOR } from '@/shared/consts';
 import { Icon } from '@/shared/ui';
 
-import { useBookmark } from '../api';
+import { useBookmarks } from '../api';
 
 interface BookmarkButtonProps {
   feedId: number;
@@ -12,7 +12,7 @@ export const BookmarkButton: React.FC<BookmarkButtonProps> = ({
   feedId,
   isBookmarked,
 }) => {
-  const { handleBookmarkFeed, isPending } = useBookmark(feedId);
+  const { handleBookmarkFeed, isPending } = useBookmarks(feedId);
 
   return (
     <button

--- a/src/features/feed-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/feed-bookmark/ui/BookmarkButton.tsx
@@ -12,7 +12,7 @@ export const BookmarkButton: React.FC<BookmarkButtonProps> = ({
   feedId,
   isBookmarked,
 }) => {
-  const { handleBookmarkFeed, isPending } = useBookmarks(feedId);
+  const { handleBookmarkFeed, isPending } = useBookmarks(feedId, isBookmarked);
 
   return (
     <button

--- a/src/features/feed-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/feed-bookmark/ui/BookmarkButton.tsx
@@ -3,11 +3,11 @@ import { Icon } from '@/shared/ui';
 
 interface BookmarkButtonProps {
   feedId: number;
-  isBookmark: boolean;
+  isBookmarked: boolean;
 }
 
 export const BookmarkButton: React.FC<BookmarkButtonProps> = ({
-  isBookmark,
+  isBookmarked,
 }) => {
   return (
     <button className='icon icon-btn'>
@@ -15,7 +15,7 @@ export const BookmarkButton: React.FC<BookmarkButtonProps> = ({
         name='bookmark'
         width='20'
         height='20'
-        color={isBookmark ? ICON_ACTIVE_COLOR : 'none'}
+        color={isBookmarked ? ICON_ACTIVE_COLOR : 'none'}
       />
     </button>
   );

--- a/src/features/feed-bookmark/ui/BookmarkButton.tsx
+++ b/src/features/feed-bookmark/ui/BookmarkButton.tsx
@@ -1,16 +1,25 @@
 import { ICON_ACTIVE_COLOR } from '@/shared/consts';
 import { Icon } from '@/shared/ui';
 
+import { useBookmark } from '../api/useBookmark';
+
 interface BookmarkButtonProps {
   feedId: number;
   isBookmarked: boolean;
 }
 
 export const BookmarkButton: React.FC<BookmarkButtonProps> = ({
+  feedId,
   isBookmarked,
 }) => {
+  const { handleBookmarkFeed, isPending } = useBookmark(feedId);
+
   return (
-    <button className='icon icon-btn'>
+    <button
+      className='icon icon-btn'
+      onClick={() => handleBookmarkFeed()}
+      disabled={isPending}
+    >
       <Icon
         name='bookmark'
         width='20'

--- a/src/features/feed-bookmark/ui/index.ts
+++ b/src/features/feed-bookmark/ui/index.ts
@@ -1,0 +1,1 @@
+export { BookmarkButton } from './BookmarkButton';

--- a/src/features/feed-main-like/api/useLikes.tsx
+++ b/src/features/feed-main-like/api/useLikes.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { requestLikeFeed, requestUnlikeFeed } from '@/shared/axios';
+import { FeedsQueryData } from '@/shared/consts';
 import { QUERY_KEYS } from '@/shared/react-query';
 import { isErrorResponse } from '@/shared/utils';
 
-import { FeedsQueryData } from '../consts';
 import { updateLikeStatusInFeeds } from '../lib';
 
 export const useLikes = (feedId: number, isLiked: boolean) => {

--- a/src/features/feed-main-like/consts/index.ts
+++ b/src/features/feed-main-like/consts/index.ts
@@ -1,6 +1,0 @@
-import { FetchFeeds } from '@/shared/consts';
-
-export interface FeedsQueryData {
-  queryParams: number[];
-  pages: FetchFeeds[];
-}

--- a/src/features/feed-main-like/lib/index.ts
+++ b/src/features/feed-main-like/lib/index.ts
@@ -1,4 +1,4 @@
-import { FeedsQueryData } from '../consts';
+import { FeedsQueryData } from '@/shared/consts';
 
 export function updateLikeStatusInFeeds(
   previousQueryData: FeedsQueryData,

--- a/src/shared/axios/bookmark/bookmark.ts
+++ b/src/shared/axios/bookmark/bookmark.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from '../config';
+
+export async function requestBookmarkFeed(feedId: number) {
+  const { data } = await axiosInstance.put(`/feeds/${feedId}/bookmarks`);
+
+  return data;
+}
+
+export async function requestUnBookmarkFeed(feedId: number) {
+  const { data } = await axiosInstance.delete(`/feeds/${feedId}/bookmarks`);
+
+  return data;
+}

--- a/src/shared/axios/bookmark/bookmark.ts
+++ b/src/shared/axios/bookmark/bookmark.ts
@@ -1,12 +1,22 @@
 import { axiosInstance } from '../config';
 
+/**
+ * 피드 북마크 API
+ * @param feedId 피드 아이디
+ * @returns 피드 북마크 상태
+ */
 export async function requestBookmarkFeed(feedId: number) {
   const { data } = await axiosInstance.put(`/feeds/${feedId}/bookmarks`);
 
   return data;
 }
 
-export async function requestUnBookmarkFeed(feedId: number) {
+/**
+ * 피드 북마크 취소 API
+ * @param feedId 피드 아이디
+ * @returns 피드 북마크 상태
+ */
+export async function requestUnbookmarkFeed(feedId: number) {
   const { data } = await axiosInstance.delete(`/feeds/${feedId}/bookmarks`);
 
   return data;

--- a/src/shared/axios/bookmark/index.ts
+++ b/src/shared/axios/bookmark/index.ts
@@ -1,0 +1,1 @@
+export * from './bookmark';

--- a/src/shared/axios/index.ts
+++ b/src/shared/axios/index.ts
@@ -1,2 +1,3 @@
 export { axiosInstance } from './config';
 export * from './like';
+export * from './bookmark';

--- a/src/shared/consts/types/feed.ts
+++ b/src/shared/consts/types/feed.ts
@@ -1,5 +1,10 @@
 import { User } from '.';
 
+export interface FeedsQueryData {
+  queryParams: number[];
+  pages: FetchFeeds[];
+}
+
 export interface FetchFeeds {
   code: string;
   data: {

--- a/src/shared/consts/types/feed.ts
+++ b/src/shared/consts/types/feed.ts
@@ -22,7 +22,7 @@ export interface Feed {
   commentCount: number;
 
   isLiked: boolean;
-  isBookmark: boolean;
+  isBookmarked: boolean;
 
   createdAt: string;
   updatedAt: string;

--- a/src/widgets/feed-main-list/ui/Feed.tsx
+++ b/src/widgets/feed-main-list/ui/Feed.tsx
@@ -1,3 +1,4 @@
+import { BookmarkButton } from '@/features/feed-bookmark';
 import { LikeButton } from '@/features/feed-main-like';
 import { Feed as FeedProps } from '@/shared/consts';
 import { Carousel, Icon, Profile } from '@/shared/ui';
@@ -9,12 +10,13 @@ export const Feed: React.FC<{ feed: FeedProps }> = ({ feed }) => {
   const {
     id,
     user,
+    updatedAt,
     content,
     images,
     likeCount,
     commentCount,
-    updatedAt,
     isLiked,
+    isBookmark,
   } = feed;
 
   return (
@@ -51,9 +53,7 @@ export const Feed: React.FC<{ feed: FeedProps }> = ({ feed }) => {
             </button>
           </div>
           <div className='footer-right'>
-            <button className='icon icon-btn'>
-              <Icon name='bookmark' width='20' height='20' />
-            </button>
+            <BookmarkButton feedId={id} isBookmark={isBookmark} />
           </div>
         </footer>
       </article>

--- a/src/widgets/feed-main-list/ui/Feed.tsx
+++ b/src/widgets/feed-main-list/ui/Feed.tsx
@@ -16,7 +16,7 @@ export const Feed: React.FC<{ feed: FeedProps }> = ({ feed }) => {
     likeCount,
     commentCount,
     isLiked,
-    isBookmark,
+    isBookmarked,
   } = feed;
 
   return (
@@ -53,7 +53,7 @@ export const Feed: React.FC<{ feed: FeedProps }> = ({ feed }) => {
             </button>
           </div>
           <div className='footer-right'>
-            <BookmarkButton feedId={id} isBookmark={isBookmark} />
+            <BookmarkButton feedId={id} isBookmarked={isBookmarked} />
           </div>
         </footer>
       </article>


### PR DESCRIPTION
## 작업 이유

- 피드 북마크 API Mocking 추가
- 피드 북마크 API 연동
- FeedsQueryData 공용 타입 설정

<br/>

## 작업 사항

### 1️⃣ 피드 북마크 API Mocking 추가

기존에 피드 북마크 API가 추가되어 있지 않아서 피드 북마크 API handler 추가하였습니다. (wiki 반영 - [Bookmark API Specification](https://github.com/CollaBu/pennyway-client-webview/wiki/Bookmark-API-Specification))

- 피드 북마크 API
- 피드 북마크 취소 API
- 기존에 북마크 여부를 나타내는 변수명을 수정하였습니다. (`isBookmark` -> `isBookmarked`)

### 2️⃣ 피드 북마크 API 연동

- 북마크 API의 경우 기존에 좋아요 API와 동일하게 MutationFn을 조건부로 처리하였습니다.

```typescript
mutationFn: () =>
  isBookmarked
    ? requestUnbookmarkFeed(feedId)
    : requestBookmarkFeed(feedId),
```

- 좋아요 API와 마찬가지로 사용자에게 빠른 사용자 경험을 제공해주기 위해 낙관적 업데이트 기능을 추가해두었습니다.
- 북마크 상태에 따라 북마크 API 혹은 북마크 취소 API 호출이 정상적으로 이루어지는지에 대한 테스트 코드를 추가하였습니다.

![image](https://github.com/CollaBu/pennyway-client-webview/assets/44726494/029ad621-496d-41cd-b852-beadd2f4e2a5)

### 3️⃣ FeedsQueryData 공용 타입 설정

```typescript
export interface FeedsQueryData {
  queryParams: number[];
  pages: FetchFeeds[];
}
```

좋아요 API에서 낙관적 업데이트를 위해 사용되던 타입이 북마크 API에도 사용되어, 이를 공용 폴더에 위치시켰습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [x] 북마크 및 북마크 취소 API가 정상적으로 동작하고 있나요?
- [x] useBookmarks에서 개선할 부분이 있나요?
- [x] useBookmarks에 대해 추가로 고려해야 할 테스트가 있나요?

<br/>

## 발견한 이슈

- 없음