### PR TITLE
🛠️ BottomSheetModal 구분선 오류 수정

### DIFF
--- a/src/shared/ui/button/BasicButton.scss
+++ b/src/shared/ui/button/BasicButton.scss
@@ -12,7 +12,6 @@
 .bsm-option {
   width: 280px;
   height: 46px;
-  background-color: $gray1;
   color: $gray5;
   text-align: center;
   border-radius: 4px;

--- a/src/shared/ui/button/BasicButton.scss
+++ b/src/shared/ui/button/BasicButton.scss
@@ -11,7 +11,7 @@
 
 .bsm-option {
   width: 280px;
-  height: 40px;
+  height: 46px;
   background-color: $gray1;
   color: $gray5;
   text-align: center;

--- a/src/shared/ui/modal/BottomSheetModal.scss
+++ b/src/shared/ui/modal/BottomSheetModal.scss
@@ -12,10 +12,10 @@
     border-radius: 4px;
   }
   .option-divider {
-    width: 240px;
+    width: 244px;
     margin: 0 auto;
     border: none;
-    height: 1px;
-    background-color: $gray3;
+    height: 0.5px;
+    background-color: $gray2;
   }
 }

--- a/src/shared/ui/modal/ModalOverlay.scss
+++ b/src/shared/ui/modal/ModalOverlay.scss
@@ -1,6 +1,6 @@
 @mixin overlay($isModal: false) {
   position: absolute;
-  z-index: 10;
+  z-index: 100;
 
   @if $isModal {
     top: 50%;

--- a/src/widgets/feed-main-list/ui/FeedMainList.scss
+++ b/src/widgets/feed-main-list/ui/FeedMainList.scss
@@ -6,7 +6,7 @@
   .feed-wrapper:not(:last-child)::after {
     content: '';
     display: block;
-    height: 1px;
+    height: 0.5px;
     background-color: $gray2;
     margin: 15px 0 14px;
   }

--- a/src/widgets/feed-main-list/ui/SkeletonFeedMainList.scss
+++ b/src/widgets/feed-main-list/ui/SkeletonFeedMainList.scss
@@ -4,7 +4,7 @@
   .skeleton-feed-wrapper:not(:last-child)::after {
     content: '';
     display: block;
-    height: 1px;
+    height: 0.5px;
     background-color: $gray2;
     margin: 15px 0 14px;
   }


### PR DESCRIPTION
## 작업 이유

- #19 이슈 해결

<br/>

## 작업 사항

- 버튼 크기 값 피그마에 맞춰서 일부 수정
- z-index 값 수정 (바텀시트 모달이 콘텐츠보다 z-index 값이 낮았음)
- 구분 선 0.5 픽셀 수정

![image](https://github.com/CollaBu/pennyway-client-webview/assets/44726494/56bf9f07-5f9b-4d0e-957c-157a6291e4ab)

기존에 button에 크기 값을 설정해줘서 동적으로 변할 수 있는 상태였습니다. 이로 인해, 실제 button 태그의 크기가 예측 가능한 상태가 아니다 보니 일부 height 에 대해서는 hr 구분선이 정상적으로 표시되고 있지 않았습니다.

해당 문제를 해결하기 위해 button 태그의 색상을 제거하고, 전역 설정에 있는 `button { background-color: transparent; }`을 적용함으로써 해결하였습니다.

<div align="center">
<img src="https://github.com/CollaBu/pennyway-client-webview/assets/44726494/b1ab2db2-06e7-43d5-9409-7fa0a7f058dd" height="360" />
<p>위 0.5px, 아래 1px</p>
</div>

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [x] 0.5 픽셀이 정상적으로 동작되나요?
- [x] 이슈 발생 원인에 대해 인지하셨나요?

<br/>

## 발견한 이슈

- 없음