### PR TITLE
✨ 피드 신고하기 API

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -36,7 +36,12 @@ module.exports = {
     'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
     eqeqeq: 'error',
     'dot-notation': 'error',
-    'no-unused-vars': 'error',
+    'no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '_',
+      },
+    ],
     'react/jsx-no-useless-fragment': 'error',
     'react/react-in-jsx-scope': 'off',
     'fsd-import/fsd-relative-path': 'error',

--- a/src/features/feed-reports/api/index.ts
+++ b/src/features/feed-reports/api/index.ts
@@ -1,0 +1,1 @@
+export { useSubmitReports } from './useSubmitReports';

--- a/src/features/feed-reports/api/useSubmitReports.tsx
+++ b/src/features/feed-reports/api/useSubmitReports.tsx
@@ -1,5 +1,25 @@
-export const useSubmitReports = (feedId: number) => {
-  feedId;
+import { useMutation } from '@tanstack/react-query';
 
-  return;
+import { axiosInstance } from '@/shared/axios';
+
+interface ReportBody {
+  category: string;
+  content: string;
+  isBlind: boolean;
+}
+
+async function requestFeedReports(feedId: number, body: ReportBody) {
+  const { data } = await axiosInstance.post(`feeds/${feedId}/reports`, body);
+
+  return data;
+}
+
+export const useSubmitReports = (feedId: number) => {
+  const { mutate: reportFeed, isPending } = useMutation({
+    mutationFn: (body: ReportBody) => requestFeedReports(feedId, body),
+    onError: () => {},
+    onSuccess: () => {},
+  });
+
+  return { reportFeed, isPending };
 };

--- a/src/features/feed-reports/api/useSubmitReports.tsx
+++ b/src/features/feed-reports/api/useSubmitReports.tsx
@@ -1,0 +1,5 @@
+export const useSubmitReports = (feedId: number) => {
+  feedId;
+
+  return;
+};

--- a/src/features/feed-reports/api/useSubmitReports.tsx
+++ b/src/features/feed-reports/api/useSubmitReports.tsx
@@ -15,11 +15,11 @@ async function requestFeedReports(feedId: number, body: ReportBody) {
 }
 
 export const useSubmitReports = (feedId: number) => {
-  const { mutate: reportFeed, isPending } = useMutation({
+  const { mutateAsync: reportFeedAsync, isPending } = useMutation({
     mutationFn: (body: ReportBody) => requestFeedReports(feedId, body),
     onError: () => {},
     onSuccess: () => {},
   });
 
-  return { reportFeed, isPending };
+  return { reportFeedAsync, isPending };
 };

--- a/src/features/feed-reports/consts/reports.ts
+++ b/src/features/feed-reports/consts/reports.ts
@@ -8,4 +8,4 @@ export const REPORT_CATEGORIES = [
   '기타',
 ];
 
-export const MAX_REPORT_CONTENT_LENGTH = 100;
+export const MAX_REPORT_CONTENT_LENGTH = 60;

--- a/src/features/feed-reports/consts/reports.ts
+++ b/src/features/feed-reports/consts/reports.ts
@@ -1,18 +1,11 @@
-export type ReportCategoryId = 1 | 2 | 3 | 4 | 5 | 6 | 7;
-
-interface ReportCategory {
-  id: ReportCategoryId;
-  name: string;
-}
-
-export const REPORT_CATEOGRIES: ReportCategory[] = [
-  { id: 1, name: '상업적/홍보성' },
-  { id: 2, name: '음란/선정성' },
-  { id: 3, name: '저작권 침해' },
-  { id: 4, name: '개인정보 노출' },
-  { id: 5, name: '욕설/인신공격' },
-  { id: 6, name: '반복적인 내용' },
-  { id: 7, name: '기타' },
+export const REPORT_CATEGORIES = [
+  '상업적/홍보성',
+  '음란/선정성',
+  '저작권 침해',
+  '개인정보 노출',
+  '욕설/인신공격',
+  '반복적인 내용',
+  '기타',
 ];
 
 export const MAX_REPORT_CONTENT_LENGTH = 100;

--- a/src/features/feed-reports/consts/reports.ts
+++ b/src/features/feed-reports/consts/reports.ts
@@ -9,3 +9,4 @@ export const REPORT_CATEGORIES = [
 ];
 
 export const MAX_REPORT_CONTENT_LENGTH = 60;
+export const DEFAULT_CLICKED_ID = 0;

--- a/src/features/feed-reports/model/useReportCategories.tsx
+++ b/src/features/feed-reports/model/useReportCategories.tsx
@@ -1,26 +1,10 @@
 import { useState } from 'react';
 
-import { REPORT_CATEOGRIES, ReportCategoryId } from '../consts';
+const DEFAULT_CLICKED_ID = 0;
 
 export const useReportCategories = () => {
-  const [categories, setCategories] = useState(
-    new Map<ReportCategoryId, boolean>(
-      REPORT_CATEOGRIES.map((item) => [item.id, false]),
-    ),
-  );
+  const [clickedId, setClicked] = useState(DEFAULT_CLICKED_ID);
+  const handleClickCategory = (id: number) => setClicked(id);
 
-  const handleClickCategory = (id: ReportCategoryId) => {
-    setCategories((prev) => {
-      const newCheckedItem = new Map(prev);
-      newCheckedItem.set(id, !newCheckedItem.get(id));
-      return newCheckedItem;
-    });
-  };
-
-  return { categories, handleClickCategory };
+  return { clickedId, handleClickCategory };
 };
-
-export function getCategoryName(id: ReportCategoryId) {
-  const category = REPORT_CATEOGRIES.find((item) => item.id === id);
-  return category?.name ?? '';
-}

--- a/src/features/feed-reports/model/useReportCategories.tsx
+++ b/src/features/feed-reports/model/useReportCategories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const DEFAULT_CLICKED_ID = 0;
+import { DEFAULT_CLICKED_ID } from '../consts';
 
 export const useReportCategories = () => {
   const [clickedId, setClicked] = useState(DEFAULT_CLICKED_ID);

--- a/src/features/feed-reports/ui/ConfirmReportModal.tsx
+++ b/src/features/feed-reports/ui/ConfirmReportModal.tsx
@@ -3,7 +3,7 @@ import { ModalOverlay } from '@/shared/ui/modal/ModalOverlay';
 import './ConfirmReportModal.scss';
 
 interface ConfirmReportModalProps {
-  onExecute: () => void;
+  onExecute: (_: React.FormEvent) => void;
   onExecuteIsDisabled: boolean;
   onClose: () => void;
   children: JSX.Element[];

--- a/src/features/feed-reports/ui/FeedReportsForm.tsx
+++ b/src/features/feed-reports/ui/FeedReportsForm.tsx
@@ -1,6 +1,7 @@
 import { useInput, useToggle } from '@/shared/hooks';
 import { Icon } from '@/shared/ui';
 
+import { useSubmitReports } from '../api';
 import { MAX_REPORT_CONTENT_LENGTH } from '../consts';
 import { useReportCategories, getCategoryName } from '../model';
 
@@ -8,12 +9,15 @@ import { ConfirmReportModal } from './ConfirmReportModal';
 import './FeedReportsForm.scss';
 
 interface FeedReportsFormProps {
+  feedId: number;
   onClose: () => void;
 }
 
 export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
+  feedId,
   onClose,
 }) => {
+  useSubmitReports(feedId);
   const { categories, handleClickCategory } = useReportCategories();
   const [content, handleInputContent] = useInput();
   const [isBlind, toggleBlind] = useToggle(false);

--- a/src/features/feed-reports/ui/FeedReportsForm.tsx
+++ b/src/features/feed-reports/ui/FeedReportsForm.tsx
@@ -21,7 +21,7 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
   const [content, handleInputContent] = useInput();
   const [isBlind, toggleBlind] = useToggle(false);
 
-  const { reportFeed, isPending } = useSubmitReports(feedId);
+  const { reportFeedAsync, isPending } = useSubmitReports(feedId);
 
   const handleSubmitReports = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -32,7 +32,7 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
       isBlind,
     };
 
-    reportFeed(body);
+    await reportFeedAsync(body);
     onClose();
   };
 

--- a/src/features/feed-reports/ui/FeedReportsForm.tsx
+++ b/src/features/feed-reports/ui/FeedReportsForm.tsx
@@ -17,15 +17,29 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
   feedId,
   onClose,
 }) => {
-  useSubmitReports(feedId);
   const { clickedId, handleClickCategory } = useReportCategories();
   const [content, handleInputContent] = useInput();
   const [isBlind, toggleBlind] = useToggle(false);
 
+  const { reportFeed, isPending } = useSubmitReports(feedId);
+
+  const handleSubmitReports = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const body = {
+      category: REPORT_CATEGORIES[clickedId],
+      content,
+      isBlind,
+    };
+
+    reportFeed(body);
+    onClose();
+  };
+
   return (
     <ConfirmReportModal
-      onExecute={() => {}} // API 연동 후 수정
-      onExecuteIsDisabled={false} // API 연동 후 수정
+      onExecute={handleSubmitReports} // API 연동 후 수정
+      onExecuteIsDisabled={isPending} // API 연동 후 수정
       onClose={onClose}
     >
       {/* 신고 카테고리 */}

--- a/src/features/feed-reports/ui/FeedReportsForm.tsx
+++ b/src/features/feed-reports/ui/FeedReportsForm.tsx
@@ -2,8 +2,8 @@ import { useInput, useToggle } from '@/shared/hooks';
 import { Icon } from '@/shared/ui';
 
 import { useSubmitReports } from '../api';
-import { MAX_REPORT_CONTENT_LENGTH } from '../consts';
-import { useReportCategories, getCategoryName } from '../model';
+import { MAX_REPORT_CONTENT_LENGTH, REPORT_CATEGORIES } from '../consts';
+import { useReportCategories } from '../model';
 
 import { ConfirmReportModal } from './ConfirmReportModal';
 import './FeedReportsForm.scss';
@@ -18,7 +18,7 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
   onClose,
 }) => {
   useSubmitReports(feedId);
-  const { categories, handleClickCategory } = useReportCategories();
+  const { clickedId, handleClickCategory } = useReportCategories();
   const [content, handleInputContent] = useInput();
   const [isBlind, toggleBlind] = useToggle(false);
 
@@ -30,7 +30,7 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
     >
       {/* 신고 카테고리 */}
       <ul className='reports-list'>
-        {[...categories].map(([id, checked]) => (
+        {REPORT_CATEGORIES.map((category, id) => (
           <li key={id} className='report-item'>
             <button
               className='checkbox-btn'
@@ -38,12 +38,16 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
               onClick={() => handleClickCategory(id)}
             >
               <Icon
-                name={checked ? 'checkbox-circle_on' : 'checkbox-circle_off'}
+                name={
+                  id === clickedId
+                    ? 'checkbox-circle_on'
+                    : 'checkbox-circle_off'
+                }
                 width='20'
                 height='20'
               />
             </button>
-            <p className='item-name b1md'>{getCategoryName(id)}</p>
+            <p className='item-name b1md'>{category}</p>
           </li>
         ))}
       </ul>

--- a/src/features/feed-reports/ui/FeedReportsForm.tsx
+++ b/src/features/feed-reports/ui/FeedReportsForm.tsx
@@ -38,8 +38,8 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
 
   return (
     <ConfirmReportModal
-      onExecute={handleSubmitReports} // API 연동 후 수정
-      onExecuteIsDisabled={isPending} // API 연동 후 수정
+      onExecute={handleSubmitReports}
+      onExecuteIsDisabled={isPending}
       onClose={onClose}
     >
       {/* 신고 카테고리 */}

--- a/src/features/feed-reports/ui/FeedReportsForm.tsx
+++ b/src/features/feed-reports/ui/FeedReportsForm.tsx
@@ -52,11 +52,7 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
               onClick={() => handleClickCategory(id)}
             >
               <Icon
-                name={
-                  id === clickedId
-                    ? 'checkbox-circle_on'
-                    : 'checkbox-circle_off'
-                }
+                name={`checkbox-circle_${id === clickedId ? 'on' : 'off'}`}
                 width='20'
                 height='20'
               />
@@ -84,7 +80,7 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
       <div className='hide-checkbox-container'>
         <button className='checkbox-btn' type='button' onClick={toggleBlind}>
           <Icon
-            name={isBlind ? 'checkbox-square_on' : 'checkbox-square_off'}
+            name={`checkbox-square_${isBlind ? 'on' : 'off'}`}
             width='20'
             height='20'
           />

--- a/src/widgets/feed-kebab/ui/FeedKebabButton.tsx
+++ b/src/widgets/feed-kebab/ui/FeedKebabButton.tsx
@@ -3,7 +3,7 @@ import { Icon } from '@/shared/ui';
 
 import { KebabMenu } from './KebabMenu';
 
-export const FeedKebabButton = () => {
+export const FeedKebabButton: React.FC<{ feedId: number }> = ({ feedId }) => {
   const [isVisibilityKebabMenu, toggleVisibility] = useToggle(false);
 
   return (
@@ -11,7 +11,9 @@ export const FeedKebabButton = () => {
       <button className='icon kebab-icon-btn' onClick={toggleVisibility}>
         <Icon name='kebab-menu' width='20' height='20' />
       </button>
-      {isVisibilityKebabMenu && <KebabMenu onClose={toggleVisibility} />}
+      {isVisibilityKebabMenu && (
+        <KebabMenu feedId={feedId} onClose={toggleVisibility} />
+      )}
     </>
   );
 };

--- a/src/widgets/feed-kebab/ui/KebabMenu.tsx
+++ b/src/widgets/feed-kebab/ui/KebabMenu.tsx
@@ -3,10 +3,11 @@ import { useToggle } from '@/shared/hooks';
 import './KebabMenu.scss';
 
 interface KebabMenuProps {
+  feedId: number;
   onClose: () => void;
 }
 
-export const KebabMenu: React.FC<KebabMenuProps> = ({ onClose }) => {
+export const KebabMenu: React.FC<KebabMenuProps> = ({ feedId, onClose }) => {
   const [isVisibilityReportsForm, toggleVisibilityReportsForm] =
     useToggle(false);
 
@@ -25,7 +26,9 @@ export const KebabMenu: React.FC<KebabMenuProps> = ({ onClose }) => {
           </button>
         </li>
       </ul>
-      {isVisibilityReportsForm && <FeedReportsForm onClose={onClose} />}
+      {isVisibilityReportsForm && (
+        <FeedReportsForm feedId={feedId} onClose={onClose} />
+      )}
     </>
   );
 };

--- a/src/widgets/feed-main-list/ui/Feed.tsx
+++ b/src/widgets/feed-main-list/ui/Feed.tsx
@@ -31,7 +31,7 @@ export const Feed: React.FC<{ feed: FeedProps }> = ({ feed }) => {
             content={calculateElapsedTime(updatedAt)}
           />
 
-          <FeedKebabButton />
+          <FeedKebabButton feedId={id} />
         </header>
         <div className='feed-content'>
           <p className='feed-text b1reg'>{content}</p>


### PR DESCRIPTION
## 작업 이유

- 피드 신고하기 API 작업

<br/>

## 작업 사항

### 1️⃣ 피드 신고하기 API

- 현재 UI가 완성되지 않아, onSuccess, onError 후속 처리가 아직 완성되었지 않습니다! 이 부분에 대해서는 이슈로 등록하였습니다.
   - #65 

### 2️⃣ 신고 카테고리

기존에 신고 카테고리를 아래 이유로 map에서 array로 변경하였습니다.

- Map 객체의 get 메서드의 타입이 string | undefined로 설정됩니다.
- 맵 객체 전체를 상태로 관리하기 보다는 클릭한 아이디에 대한 정보를 관리하는 것이 업데이트 측면에서 더 빠르다.
- 조회에 대해 많은 시간 차이가 발생하지 않는다. (`map.get(1)`, `array[1]` => O(1))


### 3️⃣ ESLint 설정

- `argsIgnorePattern: '_'를 추가하여 _를 사용하는 변수 혹은 매개변수에 대해 eslint가 동작되지 않게 설정하였습니다.


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

```typescript
const handleSubmitReports = async (event: React.FormEvent) => {
  event.preventDefault();

  const body = {
    category: REPORT_CATEGORIES[clickedId],
    content,
    isBlind,
  };

  await reportFeed(body); // 🚨 'await' has no effect on the type of this expression.ts(80007)
  onClose();
};
```

신고하기 제출 이후에 서버에 정상 반영 된 이후에 모달창을 닫도록 구현하였는데, mutation이 비동기로 잡히지 않아서 `await`가 정상적으로 적용되고 있지 않는 문제가 발생하였습니다..!

이 부분을 어떻게 처리하면 좋을까요?

<br/>

## 발견한 이슈

1. #65 
2. #67 