### PR TITLE
✨ 캐러셀 UI 및 간격 조정

### DIFF
--- a/src/widgets/feed-carousel/ui/Carousel.scss
+++ b/src/widgets/feed-carousel/ui/Carousel.scss
@@ -27,8 +27,7 @@
     justify-content: center;
     gap: 4px;
 
-    margin: 0;
-    bottom: -10px;
+    margin-bottom: 16px;
 
     .dot {
       width: 4px;
@@ -36,7 +35,7 @@
 
       margin: 0;
 
-      background-color: $gray3;
+      background-color: #ffffff66;
       box-shadow: unset;
 
       opacity: 1;

--- a/src/widgets/feed-carousel/ui/Carousel.scss
+++ b/src/widgets/feed-carousel/ui/Carousel.scss
@@ -1,5 +1,6 @@
 .carousel-container {
   overflow-x: unset;
+  margin-top: 16px;
 
   .carousel {
     overflow: unset;

--- a/src/widgets/feed-main-list/ui/Feed.scss
+++ b/src/widgets/feed-main-list/ui/Feed.scss
@@ -19,7 +19,6 @@
 
       .feed-text {
         padding: 0 20px;
-        margin-bottom: 16px;
 
         color: $gray6;
       }

--- a/src/widgets/feed-main-list/ui/Feed.scss
+++ b/src/widgets/feed-main-list/ui/Feed.scss
@@ -26,8 +26,7 @@
     }
 
     .feed-footer {
-      margin-top: 8px;
-      padding: 0 15px 3px 15px;
+      padding: 0 15px 0 20px;
 
       display: flex;
       justify-content: space-between;
@@ -35,7 +34,7 @@
 
       .footer-left {
         display: flex;
-        gap: 12px;
+        gap: 9px;
 
         .footer-count {
           display: flex;

--- a/src/widgets/profile-feed-list/ui/ProfileFeedList.scss
+++ b/src/widgets/profile-feed-list/ui/ProfileFeedList.scss
@@ -17,4 +17,8 @@
     border-radius: 10px;
     padding: 20px 1px;
   }
+
+  .feed-footer {
+    padding: 0 15px !important;
+  }
 }


### PR DESCRIPTION
## 작업 이유

- 캐러셀 UI 및 간격 조정

<br/>

## 작업 사항

### 1️⃣ 캐러셀 UI 수정

![image](https://github.com/CollaBu/pennyway-client-webview/assets/44726494/71cde266-68e2-4e08-a0b1-4632634c9735)

- 기존에 컨트롤 박스가 이미지 하단에 위치하고 있었던 UI를 이미지 내부로 이동하였습니다.

### 2️⃣ 피드 간격 수정

- 피드 메인 페이지와 프로필 페이지에서 피드의 footer 영역이 모두 `padding: 0 15px;`로 설정되어 있었던 부분을 수정하였습니다
   - 피드 메인 페이지: `padding: 0 15px 0 20px;`
   - 프로필 페이지: `padding: 0 15px !important;`

- 피드 메인 페이지 footer-left 좋아요, 댓글 박스 간격 수정 (`gap: 12px` -> `gap: 9px`)

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [x] 변경된 UI가 피그마와 동일한가요?

<br/>

## 발견한 이슈

- 현재 피그마에 메인 페이지의 피드와 프로필 페이지의 피드의 **간격, 폰트, 색상 이 조금씩 다른 것** 같습니다. 이 부분에 대해 디자인팀과 얘기하거나 프로필 페이지의 피드 UI 수정이 필요할 것 같습니다.