### PR TITLE
✨ 피드 메인 페이지 UI 업데이트

### DIFF
--- a/src/app/mocks/consts/feed.ts
+++ b/src/app/mocks/consts/feed.ts
@@ -18,43 +18,43 @@ export const feeds: Feeds = {
     images: [
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 2,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 4,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 5,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 6,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 7,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 8,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 9,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 10,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
     ],
 
@@ -89,15 +89,15 @@ export const feeds: Feeds = {
     images: [
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 2,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 3,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
     ],
 
@@ -117,23 +117,23 @@ export const feeds: Feeds = {
     images: [
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 2,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 3,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 4,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 5,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
     ],
 
@@ -153,15 +153,15 @@ export const feeds: Feeds = {
     images: [
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 2,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 3,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
     ],
 
@@ -181,15 +181,15 @@ export const feeds: Feeds = {
     images: [
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 2,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 3,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
     ],
 
@@ -209,11 +209,11 @@ export const feeds: Feeds = {
     images: [
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 2,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
     ],
 
@@ -233,7 +233,7 @@ export const feeds: Feeds = {
     images: [
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
     ],
 
@@ -253,11 +253,11 @@ export const feeds: Feeds = {
     images: [
       {
         id: 1,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
       {
         id: 2,
-        imageUrl: 'https://picsum.photos/320/400',
+        imageUrl: 'https://picsum.photos/320/320',
       },
     ],
 

--- a/src/features/feed-reports/ui/FeedReportsForm.scss
+++ b/src/features/feed-reports/ui/FeedReportsForm.scss
@@ -33,7 +33,7 @@
   width: 244px;
 
   .report-textarea {
-    padding: 10px;
+    padding: 10px 7px 10px 10px;
 
     width: calc(100% - 20px);
     height: 48px;

--- a/src/features/feed-reports/ui/FeedReportsForm.scss
+++ b/src/features/feed-reports/ui/FeedReportsForm.scss
@@ -56,7 +56,7 @@
 }
 
 .hide-checkbox-container {
-  margin: 12px 0 20px;
+  margin-bottom: 22px;
 
   display: flex;
   align-items: center;

--- a/src/features/feed-reports/ui/FeedReportsForm.scss
+++ b/src/features/feed-reports/ui/FeedReportsForm.scss
@@ -29,19 +29,17 @@
 
 .report-textarea-container {
   margin-top: 16px;
-  position: relative;
 
   width: 244px;
-  height: 72px;
 
   .report-textarea {
     padding: 10px;
 
     width: calc(100% - 20px);
-    height: calc(100% - 20px);
+    height: 48px;
 
     background-color: $gray1;
-
+    border-radius: 4px;
     resize: none;
 
     &:focus {
@@ -50,10 +48,8 @@
   }
 
   .textarea-text-count {
-    position: absolute;
-
-    right: 10px;
-    bottom: 8px;
+    margin-top: 2px;
+    text-align: right;
 
     color: $gray3;
   }

--- a/src/features/feed-reports/ui/FeedReportsForm.tsx
+++ b/src/features/feed-reports/ui/FeedReportsForm.tsx
@@ -76,9 +76,9 @@ export const FeedReportsForm: React.FC<FeedReportsFormProps> = ({
           onChange={handleInputContent}
           maxLength={MAX_REPORT_CONTENT_LENGTH}
         />
-        <span className='textarea-text-count b2md'>
+        <p className='textarea-text-count b2md'>
           {content.length}/{MAX_REPORT_CONTENT_LENGTH}
-        </span>
+        </p>
       </div>
 
       {/* 숨김 처리 체크박스 */}

--- a/src/widgets/feed-carousel/ui/Carousel.scss
+++ b/src/widgets/feed-carousel/ui/Carousel.scss
@@ -28,7 +28,7 @@
     justify-content: center;
     gap: 4px;
 
-    margin-bottom: 16px;
+    margin-bottom: 12px;
 
     .dot {
       width: 4px;

--- a/src/widgets/feed-carousel/ui/Carousel.scss
+++ b/src/widgets/feed-carousel/ui/Carousel.scss
@@ -18,7 +18,7 @@
       }
 
       img {
-        aspect-ratio: 4 / 5;
+        aspect-ratio: 1 / 1;
       }
     }
   }


### PR DESCRIPTION
## 작업 이유

- 피드 메인 페이지 UI 업데이트 반영

<br/>

## 작업 사항

### 1️⃣ 캐러셀 UI 업데이트 반영

1. 이미지 비율 조정
   - 모킹 데이터 이미지 비율: 320x400 -> 320x320
   - `aspect-ratio: 1/1;`
2. 캐러셀 컨트롤 박스 간격 조정
   - 하단 기준 16px -> 12px  

### 2️⃣ 신고하기 UI 업데이트 반영

1. 신고하기 글자 수 위치 이동
   - 글자 수 표기 내부 -> 외부
2. 숨기기 버튼 간격 수정
   - `margin: 12px 0 20px` -> `margin-bottom: 22px` 

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [x] 피그마와 동일하게 업데이트 되었나요?

<br/>

## 발견한 이슈

- 없음