### PR TITLE
✨ 피드 숨기기 애니메이션 수정 및 최대 해상도 설정

### DIFF
--- a/public/assets/sprites/common.svg
+++ b/public/assets/sprites/common.svg
@@ -177,14 +177,13 @@
       d='M13.928 7.5l-5.402 5.402-2.456-2.456'
     />
   </symbol>
-  <symbol id='check_mint-icon' viewBox='0 0 24 24'>
-    <circle cx='12' cy='12' r='10.25' stroke='#00D5E1' stroke-width='1.5' />
+  <symbol id='check_mint-icon' viewBox="0 0 12 9">
     <path
-      stroke='#00D5E1'
-      stroke-linecap='round'
-      stroke-linejoin='round'
-      stroke-width='1.5'
-      d='M16.71 9.381l-6.482 6.482-2.947-2.946'
+      d="M10.7098 1.38135L4.22768 7.86349L1.28125 4.91706"
+      stroke="#00D5E1"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
     />
   </symbol>
   <symbol id='siren-icon' viewBox='0 0 20 20'>

--- a/src/app/layout/RootLayout.scss
+++ b/src/app/layout/RootLayout.scss
@@ -1,7 +1,7 @@
 .wrap {
-  /** iPhone Pro Max 15 */
-  max-width: 430px;
-  max-height: 932px;
+  /** iPhone 15 Pro Max 430 x 932  */
+  max-width: 573.3px; // 430 pt
+  max-height: 1242.6px; // 932 pt
 
   margin: 0 auto;
 }

--- a/src/app/layout/RootLayout.scss
+++ b/src/app/layout/RootLayout.scss
@@ -1,0 +1,7 @@
+.wrap {
+  /** iPhone Pro Max 15 */
+  max-width: 430px;
+  max-height: 932px;
+
+  margin: 0 auto;
+}

--- a/src/app/layout/RootLayout.tsx
+++ b/src/app/layout/RootLayout.tsx
@@ -1,5 +1,10 @@
 import { Outlet } from 'react-router-dom';
+import './RootLayout.scss';
 
 export const RootLayout = () => {
-  return <Outlet />;
+  return (
+    <div className='wrap'>
+      <Outlet />
+    </div>
+  );
 };

--- a/src/features/feed-hides/ui/HiddenFeed.scss
+++ b/src/features/feed-hides/ui/HiddenFeed.scss
@@ -1,3 +1,9 @@
+@keyframes revealCircle {
+  to {
+    transform: rotate(180deg);
+  }
+}
+
 @keyframes fadeInCompletion {
   0% {
     opacity: 0;
@@ -18,15 +24,49 @@
     align-items: center;
 
     .feed-hidden-checkmark {
+      margin: 1px;
+
+      position: relative;
+
       display: flex;
       justify-content: center;
       align-items: center;
+      overflow: hidden;
 
-      width: 24px;
-      height: 24px;
+      width: 22px;
+      height: 22px;
 
+      border-radius: 50%;
+
+      /** Circle  */
+      &::before {
+        position: absolute;
+        width: inherit;
+        height: inherit;
+        border-radius: 50%;
+        box-shadow: inset 0 0 0 1.5px #00d5e1;
+        content: '';
+      }
+
+      /** Circle screen */
+      .cover {
+        position: absolute;
+        width: 200%;
+        height: inherit;
+        transform-origin: 50% 0;
+        background: white;
+        animation: revealCircle 0.5s ease forwards;
+      }
+
+      /** Checkmark */
       svg {
-        animation: fadeInCompletion 0.35s ease-in-out 0s forwards;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+
+        opacity: 0;
+        animation: fadeInCompletion 0.25s ease-in-out 0.5s forwards;
       }
     }
 

--- a/src/features/feed-hides/ui/HiddenFeed.tsx
+++ b/src/features/feed-hides/ui/HiddenFeed.tsx
@@ -17,7 +17,8 @@ export const HiddenFeed: React.FC<HiddenFeedProps> = ({ feedId, type }) => {
     <div className='feed-hidden-wrapper'>
       <div className='feed-hidden-container'>
         <div className='feed-hidden-checkmark'>
-          <Icon name='check_mint' width='24' height='24' />
+          <div className='cover' />
+          <Icon name='check_mint' width='12' height='9' />
         </div>
         <p className='hidden-reason-msg b2md'>{reasonMsg}</p>
         <button


### PR DESCRIPTION
## 작업 이유

- 피드 숨기기 애니메이션 수정
- 최대 크기 아이폰 15 Pro Max로 고정

<br/>

## 작업 사항

### 1️⃣ 숨기기 애니메이션 수정

기존에 버튼과 원이 동시에 표시되는 애니메이션을 다음과 같이 수정하였습니다.

1. 원이 그려집니다.
2. 원이 그려진 후 체크마크가 표시됩니다.

### 2️⃣ 최대 해상도 설정

아이폰 15 Pro Max를 기준으로 최대 너비와 높이를 432 x 932 pt 를 기준으로 작성하였습니다. pt 단위는 px로 변환하여 적용하였습니다.

- https://developer.apple.com/design/human-interface-guidelines/layout
- https://pixelsconverter.com/pt-to-px

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [x] 해상도 최대 설정이 아이폰 15 Pro Max의 개발 해상도와 동일한가요?

<br/>

## 발견한 이슈

오디오 관련 라이브러리를 적용해보았는데 타입 관련해서 에러가 발생하는 부분이 많았고 유지보수가 전혀 되어있지 않은 상태입니다. 그래서 오디오 관련 기능은 필요하다면 추후에 직접 만드는 방향으로 가야할 것 같습니다.