### PR TITLE
🛠️ Profile Page Scroll 이슈 수정

### DIFF
--- a/src/app/layout/RootLayout.tsx
+++ b/src/app/layout/RootLayout.tsx
@@ -1,6 +1,6 @@
 import { IPhoneLayout } from 'react-iphone-layout';
 import 'react-iphone-layout/dist/ReactIPhoneLayout.css';
-import { Outlet } from 'react-router-dom';
+import { Outlet, ScrollRestoration } from 'react-router-dom';
 
 import './RootLayout.scss';
 
@@ -15,6 +15,11 @@ export const RootLayout = () => {
       <div className='wrap'>
         <Outlet />
       </div>
+      <ScrollRestoration
+        getKey={(location) => {
+          return location.pathname;
+        }}
+      />
     </IPhoneLayout>
   );
 };

--- a/src/app/routers/index.tsx
+++ b/src/app/routers/index.tsx
@@ -1,4 +1,8 @@
-import { createBrowserRouter, RouteObject } from 'react-router-dom';
+import {
+  createBrowserRouter,
+  RouteObject,
+  ScrollRestoration,
+} from 'react-router-dom';
 
 import { FeedMainPage } from '@/pages/feed-main';
 import { ProfileMainPage } from '@/pages/profile';
@@ -8,7 +12,16 @@ import { RootLayout } from '../layout';
 const root: RouteObject[] = [
   {
     path: '/',
-    element: <RootLayout />,
+    element: (
+      <>
+        <RootLayout />
+        <ScrollRestoration
+          getKey={(location) => {
+            return location.pathname;
+          }}
+        />
+      </>
+    ),
     children: [
       { index: true, element: <FeedMainPage /> },
       { path: 'users/:userId', element: <ProfileMainPage /> },

--- a/src/app/routers/index.tsx
+++ b/src/app/routers/index.tsx
@@ -1,8 +1,4 @@
-import {
-  createBrowserRouter,
-  RouteObject,
-  ScrollRestoration,
-} from 'react-router-dom';
+import { createBrowserRouter, RouteObject } from 'react-router-dom';
 
 import { FeedMainPage } from '@/pages/feed-main';
 import { ProfileMainPage } from '@/pages/profile';
@@ -12,16 +8,7 @@ import { RootLayout } from '../layout';
 const root: RouteObject[] = [
   {
     path: '/',
-    element: (
-      <>
-        <RootLayout />
-        <ScrollRestoration
-          getKey={(location) => {
-            return location.pathname;
-          }}
-        />
-      </>
-    ),
+    element: <RootLayout />,
     children: [
       { index: true, element: <FeedMainPage /> },
       { path: 'users/:userId', element: <ProfileMainPage /> },

--- a/src/pages/feed-main/ui/FeedMainPage.tsx
+++ b/src/pages/feed-main/ui/FeedMainPage.tsx
@@ -1,8 +1,17 @@
+import { useEffect } from 'react';
+
+import { useFeedKebabStore } from '@/widgets/feed-kebab';
 import { FeedMainHeader } from '@/widgets/feed-main-header';
 import { FeedMainList } from '@/widgets/feed-main-list';
 import './FeedMainPage.scss';
 
 export const FeedMainPage = () => {
+  useEffect(() => {
+    return () => {
+      useFeedKebabStore.getState().closeKebab();
+    };
+  }, []);
+
   return (
     <main className='feed-main-page'>
       <FeedMainHeader />

--- a/src/widgets/feed-kebab/index.ts
+++ b/src/widgets/feed-kebab/index.ts
@@ -1,1 +1,2 @@
 export { FeedKebabButton } from './ui';
+export { useFeedKebabStore } from './store';


### PR DESCRIPTION
## 작업 이유
#81 이슈 해결

<br/>

## 작업 사항
### 1️⃣ RootLayout.tsx에 ScrollRestoration 추가
- 새 화면으로 이동할때는 스크롤을 최상단으로 이동시키고, 기존 화면으로 돌아갈때는`location.pathname` 속성을 활용해 scroll이 그대로 유지되게 설정하였습니다.
```tsx
<ScrollRestoration
  getKey={(location) => {
    return location.pathname;
  }}
/>
```
### 2️⃣ FeedMainPage 언마운트 시 Kebab메뉴 닫힘
- useFeedKebabStore를 export 했습니다.
- FeedMainPage가 언마운트 될 때, useEffect의 클린업 기능을 사용해 kebab메뉴가 닫기도록 했습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- [x] Profile Page의 경우, 스크롤이 최상단에서 랜더링되는지
- [x] Main Page의 경우, 기존 위치에서 랜더링되는지

<br/>

## 발견한 이슈
다만, iPhoneLayout의 경우에는 여전히 스크롤이 정상적으로 이동되지 않습니다. 이 부분은 package의 문제라고 생각되어 react-iphone-layout package에 issue로 등록하겠습니다.
